### PR TITLE
Attempt to fix empty modals

### DIFF
--- a/tapir/wirgarten/static/wirgarten/css/form-modal.css
+++ b/tapir/wirgarten/static/wirgarten/css/form-modal.css
@@ -1,5 +1,5 @@
 #content-frame {
-   -webkit-transition-property: min-height, max-height;
+  -webkit-transition-property: min-height, max-height;
   -moz-transition-property: min-height, max-height;
   -ms-transition-property: min-height, max-height;
   -o-transition-property: min-height, max-height;

--- a/tapir/wirgarten/static/wirgarten/css/loading-spinner.css
+++ b/tapir/wirgarten/static/wirgarten/css/loading-spinner.css
@@ -21,53 +21,102 @@
   background: #000;
 }
 .lds-spinner div:nth-child(1) {
-  transform: rotate(0deg);
+  -webkit-transform: rotate(0deg); /* WebKit */
+     -moz-transform: rotate(0deg); /* Mozilla */
+      -ms-transform: rotate(0deg); /* Internet Explorer */
+       -o-transform: rotate(0deg); /* Opera */
+          transform: rotate(0deg);
   animation-delay: -1.1s;
 }
 .lds-spinner div:nth-child(2) {
-  transform: rotate(30deg);
+  -webkit-transform: rotate(30deg); /* WebKit */
+     -moz-transform: rotate(30deg); /* Mozilla */
+      -ms-transform: rotate(30deg); /* Internet Explorer */
+       -o-transform: rotate(30deg); /* Opera */
+          transform: rotate(30deg);
   animation-delay: -1s;
 }
 .lds-spinner div:nth-child(3) {
-  transform: rotate(60deg);
+  -webkit-transform: rotate(60deg); /* WebKit */
+     -moz-transform: rotate(60deg); /* Mozilla */
+      -ms-transform: rotate(60deg); /* Internet Explorer */
+       -o-transform: rotate(60deg); /* Opera */
+          transform: rotate(60deg);
   animation-delay: -0.9s;
 }
 .lds-spinner div:nth-child(4) {
-  transform: rotate(90deg);
+  -webkit-transform: rotate(90deg); /* WebKit */
+     -moz-transform: rotate(90deg); /* Mozilla */
+      -ms-transform: rotate(90deg); /* Internet Explorer */
+       -o-transform: rotate(90deg); /* Opera */
+          transform: rotate(90deg);
   animation-delay: -0.8s;
 }
 .lds-spinner div:nth-child(5) {
-  transform: rotate(120deg);
+  -webkit-transform: rotate(120deg); /* WebKit */
+     -moz-transform: rotate(120deg); /* Mozilla */
+      -ms-transform: rotate(120deg); /* Internet Explorer */
+       -o-transform: rotate(120deg); /* Opera */
+          transform: rotate(120deg);
   animation-delay: -0.7s;
 }
 .lds-spinner div:nth-child(6) {
-  transform: rotate(150deg);
+  -webkit-transform: rotate(150deg); /* WebKit */
+     -moz-transform: rotate(150deg); /* Mozilla */
+      -ms-transform: rotate(150deg); /* Internet Explorer */
+       -o-transform: rotate(150deg); /* Opera */
+          transform: rotate(150deg);
   animation-delay: -0.6s;
 }
 .lds-spinner div:nth-child(7) {
-  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg); /* WebKit */
+     -moz-transform: rotate(180deg); /* Mozilla */
+      -ms-transform: rotate(180deg); /* Internet Explorer */
+       -o-transform: rotate(180deg); /* Opera */
+          transform: rotate(180deg);
   animation-delay: -0.5s;
 }
 .lds-spinner div:nth-child(8) {
-  transform: rotate(210deg);
+  -webkit-transform: rotate(210deg); /* WebKit */
+     -moz-transform: rotate(210deg); /* Mozilla */
+      -ms-transform: rotate(210deg); /* Internet Explorer */
+       -o-transform: rotate(210deg); /* Opera */
+          transform: rotate(210deg);
   animation-delay: -0.4s;
 }
 .lds-spinner div:nth-child(9) {
-  transform: rotate(240deg);
+  -webkit-transform: rotate(240deg); /* WebKit */
+     -moz-transform: rotate(240deg); /* Mozilla */
+      -ms-transform: rotate(240deg); /* Internet Explorer */
+       -o-transform: rotate(240deg); /* Opera */
+          transform: rotate(240deg);
   animation-delay: -0.3s;
 }
 .lds-spinner div:nth-child(10) {
-  transform: rotate(270deg);
+  -webkit-transform: rotate(270deg); /* WebKit */
+     -moz-transform: rotate(270deg); /* Mozilla */
+      -ms-transform: rotate(270deg); /* Internet Explorer */
+       -o-transform: rotate(270deg); /* Opera */
+          transform: rotate(270deg);
   animation-delay: -0.2s;
 }
 .lds-spinner div:nth-child(11) {
-  transform: rotate(300deg);
+  -webkit-transform: rotate(300deg); /* WebKit */
+     -moz-transform: rotate(300deg); /* Mozilla */
+      -ms-transform: rotate(300deg); /* Internet Explorer */
+       -o-transform: rotate(300deg); /* Opera */
+          transform: rotate(300deg);
   animation-delay: -0.1s;
 }
 .lds-spinner div:nth-child(12) {
-  transform: rotate(330deg);
+  -webkit-transform: rotate(330deg); /* WebKit */
+     -moz-transform: rotate(330deg); /* Mozilla */
+      -ms-transform: rotate(330deg); /* Internet Explorer */
+       -o-transform: rotate(330deg); /* Opera */
+          transform: rotate(330deg);
   animation-delay: 0s;
 }
+
 @keyframes lds-spinner {
   0% {
     opacity: 1;

--- a/tapir/wirgarten/static/wirgarten/js/form-modal.js
+++ b/tapir/wirgarten/static/wirgarten/js/form-modal.js
@@ -7,11 +7,13 @@ const showLoadingIndicator = (show) => {
 
 const setFrameSize = () => {
     const form = frame.contentWindow.document.getElementsByTagName("form")
-    if(form.length > 0){
-        const newHeight = form[0].getBoundingClientRect().height
-        const newWidth = form[0].getBoundingClientRect().width
-        frame.style.minHeight = frame.style.maxHeight = newHeight + 'px';
-        frame.style.minWidth = frame.style.maxWidth = newWidth + 'px';
+    if(form.length > 0) {
+       if(form[0].offsetHeight && form[0].offsetWidth){
+           frame.style.minHeight = frame.style.maxHeight = form[0].offsetHeight + 'px';
+           frame.style.minWidth = frame.style.maxWidth = form[0].offsetWidth + 'px';
+       } else {
+            setTimeout(setFrameSize, 50);
+       }
     }
 }
 
@@ -51,7 +53,7 @@ const messageEvent = eventMethod === "attachEvent"
                 }
             }
 
-            frame.style.minHeight = frame.style.maxHeight = "0px";
+            frame.style.maxHeight = frame.style.minHeight = '0px';
             frame.src=url
 
             // Adjusting the iframe height onload event
@@ -75,13 +77,12 @@ const messageEvent = eventMethod === "attachEvent"
     }
 
 MSG_HANDLERS = [
-        ["modal-close", () => FormModal.close()],
+        ["modal-close", FormModal.close],
         ["modal-save-successful", (data) => data.url && data.url != 'None' ? window.location.replace(data.url) : FormModal.close()],
         ["modal-loading-spinner", () => {
-            frame.style.minHeight = frame.style.maxHeight = "0px";
             showLoadingIndicator(true)
         }],
-        ["modal-content-resized", () => setFrameSize()]
+        ["modal-content-resized", setFrameSize]
     ]
 
 const initMessageHandlers = () => {


### PR DESCRIPTION
It was a timing issue on slow systems, I read the size of an element before it was rendered.

- getBoundingClientRect().height was sometimes undefined, resulting in the value `undefinedpx` after string concatination
- now I use offsetHeight instead, but it can be undefined as well
- in addition I check if offsetHeight and offsetWidth are set, if not, the setFrameSize function is called again with setTimeout()
