### PR TITLE
#163: Fix registration wizard performance issues

### DIFF
--- a/tapir/wirgarten/forms/registration/harvest_shares.py
+++ b/tapir/wirgarten/forms/registration/harvest_shares.py
@@ -87,10 +87,12 @@ class HarvestShareForm(forms.Form):
         self.n_columns = len(self.products)
         self.colspans = {"solidarity_price": self.n_columns}
 
-        self.solidarity_total = get_solidarity_total()
+        self.solidarity_total = f"{get_solidarity_total()}".replace(",", ".")
 
-        self.free_capacity = get_free_product_capacity(
-            harvest_share_products[0].type.id
+        self.free_capacity = (
+            f"{get_free_product_capacity(harvest_share_products[0].type.id)}".replace(
+                ",", "."
+            )
         )
 
         for prod in harvest_share_products:

--- a/tapir/wirgarten/service/payment.py
+++ b/tapir/wirgarten/service/payment.py
@@ -164,7 +164,7 @@ def get_total_payment_amount(due_date: date) -> [Payment]:
     return sum(map(lambda x: float(x.amount), payments))
 
 
-def get_solidarity_overplus(reference_date: date = date.today()):
+def get_solidarity_overplus(reference_date: date = date.today()) -> float:
     """
     Returns the total solidarity price sum for the active subscriptions during the reference date.
 

--- a/tapir/wirgarten/service/products.py
+++ b/tapir/wirgarten/service/products.py
@@ -433,7 +433,7 @@ def create_or_update_default_tax_rate(
 def get_free_product_capacity(
     product_type_id: str, reference_date: date = date.today()
 ):
-    total_capacity = (
+    total_capacity = float(
         get_active_product_capacities(reference_date)
         .get(product_type_id=product_type_id)
         .capacity
@@ -441,7 +441,7 @@ def get_free_product_capacity(
 
     used_capacity = sum(
         map(
-            lambda sub: get_product_price(sub.product, reference_date).price
+            lambda sub: float(get_product_price(sub.product, reference_date).price)
             * sub.quantity,
             get_future_subscriptions(reference_date).filter(
                 product__type_id=product_type_id
@@ -470,12 +470,13 @@ def is_product_type_available(product_type: ProductType) -> bool:
     ) > get_cheapest_product_price(product_type)
 
 
+# FIXME: duplicate code. It would be nice to have generic parameters for each product type instead of hand written ones
 def is_harvest_shares_available() -> bool:
     param = get_parameter_value(Parameter.HARVEST_SHARES_SUBSCRIBABLE)
     return param == 1 or (
         param == 2
         and is_product_type_available(
-            get_active_product_types().get(name=ProductTypes.HARVEST_SHARES)
+            ProductType.objects.get(name=ProductTypes.HARVEST_SHARES)
         )
     )
 
@@ -485,7 +486,7 @@ def is_bestellcoop_available() -> bool:
     return param == 1 or (
         param == 2
         and is_product_type_available(
-            get_active_product_types().get(name=ProductTypes.BESTELLCOOP)
+            ProductType.objects.get(name=ProductTypes.BESTELLCOOP)
         )
     )
 
@@ -495,6 +496,6 @@ def is_chicken_shares_available() -> bool:
     return param == 1 or (
         param == 2
         and is_product_type_available(
-            get_active_product_types().get(name=ProductTypes.CHICKEN_SHARES)
+            ProductType.objects.get(name=ProductTypes.CHICKEN_SHARES)
         )
     )

--- a/tapir/wirgarten/templates/wirgarten/registration/registration_wizard.html
+++ b/tapir/wirgarten/templates/wirgarten/registration/registration_wizard.html
@@ -99,9 +99,5 @@
             parent.postMessage('registration-page-change', '*');
         })
     }
-
-
-
-
 </script>
 {%endblock %}


### PR DESCRIPTION
The problem is, that every condition function in the conditions dict is executed very often. 
I didn't find the root cause of that and don't want to put too much time into it right now.

Instead I preloaded some data (like product availability), which leads to about 40x less query executions and speeds up the page a lot.