### PR TITLE
fix: migration ordering

### DIFF
--- a/tapir/wirgarten/migrations/0087_remove_subscription_solidarity_price_absolute.py
+++ b/tapir/wirgarten/migrations/0087_remove_subscription_solidarity_price_absolute.py
@@ -7,6 +7,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("wirgarten", "0086_remove_subscription_solidarity_price_percentage"),
+        ("solidarity_contribution", "0002_auto_20251212_1036"),
     ]
 
     operations = [


### PR DESCRIPTION
make all solidarity_contribution changes before dropping the column

https://github.com/FoodCoopX/wirgarten-tapir/actions/runs/20995758796/job/60351996119#step:3:1547

```
django.core.exceptions.FieldError: Cannot resolve keyword 'solidarity_price_absolute' into field. Choices are: admin_confirmed, auto_confirmed, cancellation_admin_confirmed, cancellation_ts, consent_ts, created_at, end_date, id, mandate_ref, mandate_ref_id, member, member_id, notice_period_duration, period, period_id, price_override, product, product_id, quantity, start_date, trial_disabled, trial_end_date_override, withdrawal_consent_ts
```