### PR TITLE
fix: Docker/Vite development setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       - '5173:5173'
     volumes:
       - .:/app
+      - vite_node_modules:/app/node_modules
 
 volumes:
   nginx-certs-volume:
+  vite_node_modules:

--- a/vite.Dockerfile
+++ b/vite.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Install node modules
 COPY \
     "./package.json" \
-    "./package-lock.json" \
+    "./pnpm-lock.yaml" \
     ./
 RUN pnpm install
 


### PR DESCRIPTION
## Summary
- Added named volume `vite_node_modules` to persist container's node_modules and prevent host overwriting
- Fixed Dockerfile to use `pnpm-lock.yaml` instead of `package-lock.json`

## Why
These fixes address common issues in containerized Vite development:
1. The volume mount `.:/app` overwrites container's node_modules with host's (different architecture), causing runtime errors
2. The Dockerfile referenced the wrong lock file (npm vs pnpm), causing build failures