### PR TITLE
PR zu #1037 (Produktverträge durch Admin hinterlegen)

### DIFF
--- a/src_frontend/member_profile/deliveries_and_jokers/DeliveryListCard.tsx
+++ b/src_frontend/member_profile/deliveries_and_jokers/DeliveryListCard.tsx
@@ -129,6 +129,7 @@ const DeliveryListCard: React.FC<DeliveryListCardProps> = ({
   function pickupLocationCell(delivery: Delivery) {
     return (
       <div className={"d-flex flex-column align-items-center"}>
+        <img src={delivery.pickupLocation.photoLink} alt={delivery.pickupLocation.name}/>
         <strong>{delivery.pickupLocation.name}</strong>
         <div style={{ width: "32px" }}>
           <TapirButton

--- a/src_frontend/member_profile/deliveries_and_jokers/DeliveryListCard.tsx
+++ b/src_frontend/member_profile/deliveries_and_jokers/DeliveryListCard.tsx
@@ -129,8 +129,7 @@ const DeliveryListCard: React.FC<DeliveryListCardProps> = ({
   function pickupLocationCell(delivery: Delivery) {
     return (
       <div className={"d-flex flex-column align-items-center"}>
-        <img src={delivery.pickupLocation.photoLink} alt={delivery.pickupLocation.name}/>
-        <strong>{delivery.pickupLocation.name}</strong>
+         <strong>{delivery.pickupLocation.name}</strong>
         <div style={{ width: "32px" }}>
           <TapirButton
             variant={"outline-secondary"}

--- a/src_frontend/member_profile/deliveries_and_jokers/PickupLocationDeliveryDetailsModal.tsx
+++ b/src_frontend/member_profile/deliveries_and_jokers/PickupLocationDeliveryDetailsModal.tsx
@@ -77,6 +77,7 @@ const PickupLocationDeliveryDetailsModal: React.FC<
             })}
           </ul>
         </p>
+        <img src={pickupLocation.photoLink} alt={pickupLocation.name}/>
       </Modal.Body>
     </Modal>
   );

--- a/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import "dayjs/locale/de";
+import TapirButton from "../components/TapirButton.tsx";
+import { getParameterFromUrl } from "../product_config/get_parameter_from_url.ts";
+import TapirToastContainer from "../components/TapirToastContainer.tsx";
+import { ToastData } from "../types/ToastData.ts";
+import SubscriptionChangeDatesModal from "./SubscriptionChangeDatesModal.tsx";
+import SubscriptionAddContractModal from "./SubscriptionAddContractModal.tsx";
+
+interface SubscriptionAddContractButtonProps {
+  csrfToken: string;
+}
+
+const SubscriptionAddContractButton: React.FC<
+  SubscriptionAddContractButtonProps
+> = ({ csrfToken }) => {
+  const [showModal, setShowModal] = useState(false);
+  const [subscriptionId, setSubscriptionId] = useState();
+  const [toastDatas, setToastDatas] = useState<ToastData[]>([]);
+
+  return (
+    <>
+      <TapirButton
+        icon={"post_add"}
+        variant={"outline-primary"}
+        onClick={() => {
+          const subscriptionId = getParameterFromUrl("contract");
+          if (!subscriptionId) {
+            alert("Du musst erst den Vertrag auswählen.");
+            return;
+          }
+          setSubscriptionId(subscriptionId);
+          setShowModal(true);
+        }}
+        tooltip={"Vertrag hinzufügen"}
+      />
+      {subscriptionId && (
+        <SubscriptionAddContractModal
+          csrfToken={csrfToken}
+          show={showModal}
+          subscriptionId={subscriptionId}
+          onHide={() => setShowModal(false)}
+          setToastDatas={setToastDatas}
+        />
+      )}
+      <TapirToastContainer
+        toastDatas={toastDatas}
+        setToastDatas={setToastDatas}
+      />
+    </>
+  );
+};
+
+export default SubscriptionAddContractButton;

--- a/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
@@ -14,7 +14,7 @@ const SubscriptionAddContractButton: React.FC<
   SubscriptionAddContractButtonProps
 > = ({ csrfToken }) => {
   const [showModal, setShowModal] = useState(false);
-  const [subscriptionId, setSubscriptionId] = useState();
+  const [memberId, setMemberId] = useState<string>();
   const [toastDatas, setToastDatas] = useState<ToastData[]>([]);
 
   return (
@@ -23,21 +23,21 @@ const SubscriptionAddContractButton: React.FC<
         icon={"post_add"}
         variant={"outline-primary"}
         onClick={() => {
-          const subscriptionId = getParameterFromUrl("contract");
-          if (!subscriptionId) {
-            alert("Du musst erst den Vertrag auswählen.");
+          const memberId = getParameterFromUrl("member");
+          if (!memberId) {
+            alert("Du musst erst ein Mitglied auswählen. Du kannst rechts unter 'Mitglied' suchen, oder über die Mitgliederliste eines auswählen und auf 'Verträge anzeigen'.");
             return;
           }
-          setSubscriptionId(subscriptionId);
+          setMemberId(memberId);
           setShowModal(true);
         }}
         tooltip={"Vertrag hinzufügen"}
       />
-      {subscriptionId && (
+      {memberId && (
         <SubscriptionAddContractModal
           csrfToken={csrfToken}
           show={showModal}
-          subscriptionId={subscriptionId}
+          memberId={memberId}
           onHide={() => setShowModal(false)}
           setToastDatas={setToastDatas}
         />

--- a/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
@@ -4,7 +4,6 @@ import TapirButton from "../components/TapirButton.tsx";
 import { getParameterFromUrl } from "../product_config/get_parameter_from_url.ts";
 import TapirToastContainer from "../components/TapirToastContainer.tsx";
 import { ToastData } from "../types/ToastData.ts";
-import SubscriptionChangeDatesModal from "./SubscriptionChangeDatesModal.tsx";
 import SubscriptionAddContractModal from "./SubscriptionAddContractModal.tsx";
 
 interface SubscriptionAddContractButtonProps {

--- a/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractButton.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
 import "dayjs/locale/de";
+import React, { useState } from "react";
 import TapirButton from "../components/TapirButton.tsx";
-import { getParameterFromUrl } from "../product_config/get_parameter_from_url.ts";
 import TapirToastContainer from "../components/TapirToastContainer.tsx";
+import { getParameterFromUrl } from "../product_config/get_parameter_from_url.ts";
 import { ToastData } from "../types/ToastData.ts";
 import SubscriptionAddContractModal from "./SubscriptionAddContractModal.tsx";
 
@@ -25,7 +25,9 @@ const SubscriptionAddContractButton: React.FC<
         onClick={() => {
           const memberId = getParameterFromUrl("member");
           if (!memberId) {
-            alert("Du musst erst ein Mitglied auswählen. Du kannst rechts unter 'Mitglied' suchen, oder über die Mitgliederliste eines auswählen und auf 'Verträge anzeigen'.");
+            alert(
+              "Du musst erst ein Mitglied auswählen. Du kannst rechts unter 'Mitglied' suchen, oder über die Mitgliederliste eines auswählen und auf 'Verträge anzeigen'.",
+            );
             return;
           }
           setMemberId(memberId);

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -7,6 +7,8 @@ import {
   DeliveriesApi,
   GrowingPeriod,
   Member,
+  MemberPaymentRhythmData,
+  PaymentsApi,
   PickupLocation,
   PickupLocationsApi,
   Product,
@@ -33,9 +35,11 @@ const SubscriptionAddButtonModal: React.FC<
   const coopApi = useApi(CoopApi, csrfToken);
   const deliveriesApi = useApi(DeliveriesApi, csrfToken);
   const pickupApi = useApi(PickupLocationsApi, csrfToken)
+  const paymentsApi = useApi(PaymentsApi, csrfToken)
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription>();
   const [memberData, setMemberData] = useState<Member>();
+  const [paymentsData, setPaymentsData] = useState<MemberPaymentRhythmData>();
   const [productList, setProductList] = useState<Product[]>();
   const [periodList, setPeriodList] = useState<GrowingPeriod[]>();
   const [pickupLocationsList, setPickupLocationsList] = useState<PickupLocation[]>();
@@ -43,6 +47,7 @@ const SubscriptionAddButtonModal: React.FC<
   const [product, setProduct] = useState<Product>();
   const [startDate, setStartDate] = useState<Date>();
   const [endDate, setEndDate] = useState<Date | null | undefined>();
+  const [paymentRhythm, setPaymentRhythm] = useState<string>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
@@ -146,6 +151,26 @@ const SubscriptionAddButtonModal: React.FC<
         .finally(() => setLoading(false));
     }, [show]);
 
+  useEffect(() => {
+    if (!show) return;
+
+    setLoading(true);
+
+    paymentsApi
+      .paymentsApiMemberPaymentRhythmDataRetrieve({ memberId: memberId })
+      .then((response) => {
+        setPaymentsData(response)
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der persönliche Daten",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [show]);
+
 
   function getBodyContent() {
     if (loading) {
@@ -247,6 +272,30 @@ const SubscriptionAddButtonModal: React.FC<
                 ))}
               </Form.Select>
             </Form.Group>
+          )}
+        </Row>
+        <Row>
+          {paymentsData && (
+            <Form.Group>
+              <Form.Label>Zahlungsintervall </Form.Label>
+              {paymentsData.currentRhythm && (
+                // TODO: get German name from paymentsData.allowedRythms
+                  <Form.Label>: {paymentsData.currentRhythm}</Form.Label>
+              )}
+              {!paymentsData.currentRhythm && (
+                <Form.Select
+                  onChange={(event) => {
+                    // @ts-ignore
+                    setPaymentRhythm(Object.keys(paymentsData.allowedRhythms)[event.target.value]);
+                    console.log(paymentsData.currentRhythm)
+                  }}>
+                  // TODO: When selecting for the first time opt.id is undefined and the indexes dont seem to match
+                  {Object.values(paymentsData?.allowedRhythms).map((opt, index) => (
+                    <option key={opt} value={index}>{opt}</option>
+                  ))}
+                </Form.Select>
+              )}
+              </Form.Group>
           )}
         </Row>
       </>

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -1,0 +1,233 @@
+import React, { useEffect, useState } from "react";
+import { Alert, Col, Form, Modal, Row, Spinner } from "react-bootstrap";
+import { ToastData } from "../types/ToastData.ts";
+import { useApi } from "../hooks/useApi.ts";
+import { CoopApi, Member, Subscription, SubscriptionsApi } from "../api-client";
+import { handleRequestError } from "../utils/handleRequestError.ts";
+import formatSubscription from "../utils/formatSubscription.ts";
+import { formatDateNumeric } from "../utils/formatDateNumeric.ts";
+import dayjs from "dayjs";
+import TapirButton from "../components/TapirButton.tsx";
+
+interface SubscriptionChangeDatesModalProps {
+  onHide: () => void;
+  show: boolean;
+  subscriptionId: string;
+  csrfToken: string;
+  setToastDatas: React.Dispatch<React.SetStateAction<ToastData[]>>;
+}
+
+const SubscriptionAddButtonModal: React.FC<
+  SubscriptionChangeDatesModalProps
+> = ({ onHide, show, subscriptionId, csrfToken, setToastDatas }) => {
+  const subscriptionsApi = useApi(SubscriptionsApi, csrfToken);
+  const coopApi = useApi(CoopApi, csrfToken);
+  const [loading, setLoading] = useState(true);
+  const [subscription, setSubscription] = useState<Subscription>();
+  const [memberId, setMemberId] = useState<string>();
+  const [memberData, setMemberData] = useState<Member>();
+  const [startDate, setStartDate] = useState<Date>();
+  const [endDate, setEndDate] = useState<Date | null | undefined>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!show) {
+      return;
+    }
+
+    subscriptionsApi
+      .subscriptionsSubscriptionsRetrieve({ id: subscriptionId })
+      .then((subscription) => {
+        setSubscription(subscription);
+        setMemberId(subscription.member);
+      })
+      .catch(
+        async (error) =>
+          await handleRequestError(
+            error,
+            "Fehler bei der Bestätigung der Bestellung",
+            setToastDatas,
+          ),
+      )
+      .finally(() => setLoading(false));
+
+    setLoading(true);
+  }, [show]);
+
+  useEffect(() => {
+    if (!show || !memberId) {
+      return;
+    }
+
+    coopApi.coopMembersRetrieve({ id: memberId }).then(setMemberData);
+  }, [memberId, show]);
+
+  useEffect(() => {
+    if (!subscription) {
+      return;
+    }
+
+    setStartDate(subscription.startDate);
+    setEndDate(subscription.endDate);
+  }, [subscription]);
+
+  function onConfirmChange() {
+    if (!subscription || !startDate || !endDate) {
+      return;
+    }
+
+    if (
+      startDate === subscription.startDate &&
+      endDate === subscription.endDate
+    ) {
+      alert("Die Daten sind nicht geändert worden.");
+      return;
+    }
+
+    setLoading(true);
+
+    subscriptionsApi
+      .subscriptionsApiDatesChangeCreate({
+        subscriptionDateChangeRequest: {
+          subscriptionId: subscriptionId,
+          startDate: startDate,
+          endDate: endDate,
+        },
+      })
+      .then((response) => {
+        if (response.orderConfirmed) {
+          location.reload();
+          onHide();
+        } else {
+          setError(response.error ?? undefined);
+        }
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der Verteilstationen",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    setError(undefined);
+  }, [startDate, endDate]);
+
+  function getBodyContent() {
+    if (loading) {
+      return <Spinner />;
+    }
+
+    if (subscription === undefined) {
+      return <p>Fehler beim Laden der Vertragsdaten</p>;
+    }
+
+    return (
+      <>
+        <Row>
+          <Col>
+            <div>
+              Aktuelle Vertragsdaten:
+              <ul>
+                <li>Produkt: {formatSubscription(subscription)}</li>
+                <li>Start: {formatDateNumeric(subscription.startDate)}</li>
+                <li>End: {formatDateNumeric(subscription.endDate)}</li>
+                {memberData && (
+                  <li>
+                    Mitglied: {memberData.firstName} {memberData.lastName}{" "}
+                    {memberData.memberNo && "#" + memberData.memberNo}
+                  </li>
+                )}
+              </ul>
+            </div>
+          </Col>
+        </Row>
+        {subscription && (
+          <Row>
+            <Col>
+              {startDate && (
+                <Form.Group>
+                  <Form.Label>Start-Datum</Form.Label>
+                  <Form.Control
+                    type={"date"}
+                    value={dayjs(startDate).format("YYYY-MM-DD")}
+                    onChange={(event) => {
+                      setStartDate(new Date(event.target.value));
+                    }}
+                  />
+                </Form.Group>
+              )}
+            </Col>
+            <Col>
+              {endDate && (
+                <Form.Group>
+                  <Form.Label>End-Datum</Form.Label>
+                  <Form.Control
+                    type={"date"}
+                    value={dayjs(endDate).format("YYYY-MM-DD")}
+                    onChange={(event) => {
+                      setEndDate(new Date(event.target.value));
+                    }}
+                  />
+                </Form.Group>
+              )}
+            </Col>
+          </Row>
+        )}
+        {error && (
+          <Row className={"mt-4"}>
+            <Col>
+              <Alert variant={"danger"}>{error}</Alert>
+            </Col>
+          </Row>
+        )}
+        <Row className={"mt-2"}>
+          <Col>
+            <p>
+              Das End-Datum darf nur am Tag der Kommissioniervariable gesetzt
+              werden (sehe Konfig-Seite).
+            </p>
+            <p>
+              Wenn das End-Datum nicht am Vertragsperiode-Ende gesetzt wird,
+              wird der Vertrag als gekündigt markiert: es wird nicht mehr
+              verlängert. Soll dieses Vertrag schon verlängert worden sein, wird
+              die Verlängerung gelöscht.
+            </p>
+            <p>
+              Die Zahlungsreihe für dieses Mitglied soll geprüft werden: es
+              ergeben sich ggf. Rückzahlungen
+            </p>
+            <p>Das Mitglied wird kein automatisierte Mail bekommen.</p>
+          </Col>
+        </Row>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Modal onHide={onHide} show={show} centered={true} size={"lg"}>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            <h4>Vertrag hinzufügen</h4>
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{getBodyContent()}</Modal.Body>
+        <Modal.Footer>
+          <TapirButton
+            variant={"primary"}
+            icon={"save"}
+            text={"Vertrag hinzufügen"}
+            loading={loading}
+            onClick={onConfirmChange}
+          />
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+};
+
+export default SubscriptionAddButtonModal;

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -2,181 +2,204 @@ import React, { useEffect, useState } from "react";
 import { Alert, Col, Form, Modal, Row, Spinner } from "react-bootstrap";
 import { ToastData } from "../types/ToastData.ts";
 import { useApi } from "../hooks/useApi.ts";
-import { CoopApi, Member, Subscription, SubscriptionsApi } from "../api-client";
+import {
+  CoopApi,
+  DeliveriesApi,
+  GrowingPeriod,
+  Member,
+  PickupLocation,
+  PickupLocationsApi,
+  Product,
+  Subscription,
+  SubscriptionsApi
+} from "../api-client";
 import { handleRequestError } from "../utils/handleRequestError.ts";
-import formatSubscription from "../utils/formatSubscription.ts";
-import { formatDateNumeric } from "../utils/formatDateNumeric.ts";
 import dayjs from "dayjs";
 import TapirButton from "../components/TapirButton.tsx";
 
-interface SubscriptionChangeDatesModalProps {
+interface SubscriptionAddContractModalProps {
   onHide: () => void;
   show: boolean;
-  subscriptionId: string;
+  memberId: string;
   csrfToken: string;
   setToastDatas: React.Dispatch<React.SetStateAction<ToastData[]>>;
 }
 
+// @ts-ignore
 const SubscriptionAddButtonModal: React.FC<
-  SubscriptionChangeDatesModalProps
-> = ({ onHide, show, subscriptionId, csrfToken, setToastDatas }) => {
+  SubscriptionAddContractModalProps
+> = ({ onHide, show, memberId, csrfToken, setToastDatas }) => {
   const subscriptionsApi = useApi(SubscriptionsApi, csrfToken);
   const coopApi = useApi(CoopApi, csrfToken);
+  const deliveriesApi = useApi(DeliveriesApi, csrfToken);
+  const pickupApi = useApi(PickupLocationsApi, csrfToken)
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription>();
-  const [memberId, setMemberId] = useState<string>();
   const [memberData, setMemberData] = useState<Member>();
+  const [productList, setProductList] = useState<Product[]>();
+  const [periodList, setPeriodList] = useState<GrowingPeriod[]>();
+  const [pickupLocationsList, setPickupLocationsList] = useState<PickupLocation[]>();
+  const [period, setPeriod] = useState<GrowingPeriod>();
+  const [product, setProduct] = useState<Product>();
   const [startDate, setStartDate] = useState<Date>();
   const [endDate, setEndDate] = useState<Date | null | undefined>();
   const [error, setError] = useState<string>();
 
   useEffect(() => {
-    if (!show) {
-      return;
-    }
+      if (!show) return;
 
-    subscriptionsApi
-      .subscriptionsSubscriptionsRetrieve({ id: subscriptionId })
-      .then((subscription) => {
-        setSubscription(subscription);
-        setMemberId(subscription.member);
-      })
-      .catch(
-        async (error) =>
-          await handleRequestError(
+      setLoading(true);
+
+      coopApi
+        .coopMembersRetrieve({ id: memberId })
+        .then((response) => {
+          setMemberData(response)
+        })
+        .catch((error) =>
+          handleRequestError(
             error,
-            "Fehler bei der Bestätigung der Bestellung",
+            "Fehler beim Laden der persönliche Daten",
             setToastDatas,
           ),
-      )
-      .finally(() => setLoading(false));
-
-    setLoading(true);
-  }, [show]);
+        )
+        .finally(() => setLoading(false));
+    }, [show]);
 
   useEffect(() => {
-    if (!show || !memberId) {
-      return;
-    }
+      if (!show) return;
 
-    coopApi.coopMembersRetrieve({ id: memberId }).then(setMemberData);
-  }, [memberId, show]);
+      setLoading(true);
 
-  useEffect(() => {
-    if (!subscription) {
-      return;
-    }
-
-    setStartDate(subscription.startDate);
-    setEndDate(subscription.endDate);
-  }, [subscription]);
-
-  function onConfirmChange() {
-    if (!subscription || !startDate || !endDate) {
-      return;
-    }
-
-    if (
-      startDate === subscription.startDate &&
-      endDate === subscription.endDate
-    ) {
-      alert("Die Daten sind nicht geändert worden.");
-      return;
-    }
-
-    setLoading(true);
-
-    subscriptionsApi
-      .subscriptionsApiDatesChangeCreate({
-        subscriptionDateChangeRequest: {
-          subscriptionId: subscriptionId,
-          startDate: startDate,
-          endDate: endDate,
-        },
-      })
-      .then((response) => {
-        if (response.orderConfirmed) {
-          location.reload();
-          onHide();
-        } else {
-          setError(response.error ?? undefined);
-        }
-      })
-      .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der Verteilstationen",
-          setToastDatas,
-        ),
-      )
-      .finally(() => setLoading(false));
-  }
+      subscriptionsApi
+        .subscriptionsProductsList()
+        .then((response) => {
+          setProductList(response)
+        })
+        .catch((error) =>
+          handleRequestError(
+            error,
+            "Fehler beim Laden der Produktliste",
+            setToastDatas,
+          ),
+        )
+        .finally(() => setLoading(false));
+    }, [show]);
 
   useEffect(() => {
-    setError(undefined);
-  }, [startDate, endDate]);
+      if (!show) return;
+
+      setLoading(true);
+
+      deliveriesApi
+        .deliveriesGrowingPeriodsList()
+        .then((response) => {
+          setPeriodList(response)
+        })
+        .catch((error) =>
+          handleRequestError(
+            error,
+            "Fehler beim Laden der Produktliste",
+            setToastDatas,
+          ),
+        )
+        .finally(() => setLoading(false));
+    }, [show]);
+
+  useEffect(() => {
+      if (!show) return;
+
+      setLoading(true);
+
+      pickupApi
+        .pickupLocationsPickupLocationsList()
+        .then((response) => {
+          setPickupLocationsList(response)
+        })
+        .catch((error) =>
+          handleRequestError(
+            error,
+            "Fehler beim Laden der Produktliste",
+            setToastDatas,
+          ),
+        )
+        .finally(() => setLoading(false));
+    }, [show]);
+
+
+  useEffect(() => {
+      if (!show) return;
+
+      setLoading(true);
+
+      pickupApi
+        .pickupLocationsPickupLocationsList()
+        .then((response) => {
+          setPickupLocationsList(response)
+        })
+        .catch((error) =>
+          handleRequestError(
+            error,
+            "Fehler beim Laden der Produktliste",
+            setToastDatas,
+          ),
+        )
+        .finally(() => setLoading(false));
+    }, [show]);
+
 
   function getBodyContent() {
     if (loading) {
       return <Spinner />;
     }
-
-    if (subscription === undefined) {
-      return <p>Fehler beim Laden der Vertragsdaten</p>;
+    if (memberData === undefined) {
+      return <p>Fehler beim Laden der Mitgliedsdaten</p>;
     }
-
     return (
       <>
         <Row>
+          {periodList && (
+            <Form.Group>
+              <Form.Label>Vertragsperiode</Form.Label>
+              <Form.Select
+                onChange={(event) => {
+                  // @ts-ignore
+                  setPeriod(periodList[event.target.value]);
+
+                }}>
+                // TODO: When selecting for the first time opt.id is undefined
+                {periodList.map((opt, index) => (
+                  <option key={opt.id} value={index}>{dayjs(opt.startDate).format("YYYY")}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          )}
+        </Row>
+        <Row>
           <Col>
-            <div>
-              Aktuelle Vertragsdaten:
-              <ul>
-                <li>Produkt: {formatSubscription(subscription)}</li>
-                <li>Start: {formatDateNumeric(subscription.startDate)}</li>
-                <li>End: {formatDateNumeric(subscription.endDate)}</li>
-                {memberData && (
-                  <li>
-                    Mitglied: {memberData.firstName} {memberData.lastName}{" "}
-                    {memberData.memberNo && "#" + memberData.memberNo}
-                  </li>
-                )}
-              </ul>
-            </div>
+            <Form.Group id={"start_date"}>
+              <Form.Label>Start-Datum</Form.Label>
+              <Form.Control
+                type={"date"}
+                value={dayjs(period?.startDate).format("YYYY-MM-DD")}
+                onChange={(event) => {
+                  setStartDate(new Date(event.target.value));
+                }}
+              />
+            </Form.Group>
+          </Col>
+          <Col>
+            <Form.Group>
+              <Form.Label>End-Datum</Form.Label>
+              <Form.Control
+                type={"date"}
+                value={dayjs(period?.endDate).format("YYYY-MM-DD")}
+                onChange={(event) => {
+                  setEndDate(new Date(event.target.value));
+                }}
+              />
+            </Form.Group>
           </Col>
         </Row>
-        {subscription && (
-          <Row>
-            <Col>
-              {startDate && (
-                <Form.Group>
-                  <Form.Label>Start-Datum</Form.Label>
-                  <Form.Control
-                    type={"date"}
-                    value={dayjs(startDate).format("YYYY-MM-DD")}
-                    onChange={(event) => {
-                      setStartDate(new Date(event.target.value));
-                    }}
-                  />
-                </Form.Group>
-              )}
-            </Col>
-            <Col>
-              {endDate && (
-                <Form.Group>
-                  <Form.Label>End-Datum</Form.Label>
-                  <Form.Control
-                    type={"date"}
-                    value={dayjs(endDate).format("YYYY-MM-DD")}
-                    onChange={(event) => {
-                      setEndDate(new Date(event.target.value));
-                    }}
-                  />
-                </Form.Group>
-              )}
-            </Col>
-          </Row>
-        )}
         {error && (
           <Row className={"mt-4"}>
             <Col>
@@ -190,18 +213,41 @@ const SubscriptionAddButtonModal: React.FC<
               Das End-Datum darf nur am Tag der Kommissioniervariable gesetzt
               werden (sehe Konfig-Seite).
             </p>
-            <p>
-              Wenn das End-Datum nicht am Vertragsperiode-Ende gesetzt wird,
-              wird der Vertrag als gekündigt markiert: es wird nicht mehr
-              verlängert. Soll dieses Vertrag schon verlängert worden sein, wird
-              die Verlängerung gelöscht.
-            </p>
-            <p>
-              Die Zahlungsreihe für dieses Mitglied soll geprüft werden: es
-              ergeben sich ggf. Rückzahlungen
-            </p>
-            <p>Das Mitglied wird kein automatisierte Mail bekommen.</p>
           </Col>
+        </Row>
+        <Row>
+          {periodList && (
+            <Form.Group>
+              <Form.Label>Produkttyp</Form.Label>
+              <Form.Select
+                onChange={(event) => {
+                  // @ts-ignore
+                  setProduct(productList[event.target.value]);
+                }}>
+                // TODO: When selecting for the first time opt.id is undefined
+                {productList?.map((opt, index) => (
+                  <option key={opt.id} value={index}>{opt.name}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          )}
+        </Row>
+        <Row>
+          {pickupLocationsList && (
+            <Form.Group>
+              <Form.Label>Abholort</Form.Label>
+              <Form.Select
+                onChange={(event) => {
+                  // @ts-ignore
+                  setProduct(pickupLocationsList[event.target.value]);
+                }}>
+                // TODO: When selecting for the first time opt.id is undefined
+                {pickupLocationsList?.map((opt, index) => (
+                  <option key={opt.id} value={index}>{opt.name}</option>
+                ))}
+              </Form.Select>
+            </Form.Group>
+          )}
         </Row>
       </>
     );
@@ -212,17 +258,22 @@ const SubscriptionAddButtonModal: React.FC<
       <Modal onHide={onHide} show={show} centered={true} size={"lg"}>
         <Modal.Header closeButton>
           <Modal.Title>
-            <h4>Vertrag hinzufügen</h4>
+            {memberData && (
+              <h4>
+                Neuer Vertrag für {memberData.firstName} {memberData.lastName}{", "} {memberData.city}
+              </h4>
+            )}
           </Modal.Title>
         </Modal.Header>
-        <Modal.Body>{getBodyContent()}</Modal.Body>
+        <Modal.Body>
+          {getBodyContent()}
+        </Modal.Body>
         <Modal.Footer>
           <TapirButton
             variant={"primary"}
             icon={"save"}
             text={"Vertrag hinzufügen"}
             loading={loading}
-            onClick={onConfirmChange}
           />
         </Modal.Footer>
       </Modal>

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -5,18 +5,18 @@ import {
   CoopApi,
   DeliveriesApi,
   GrowingPeriod,
-  Member,
-  MemberPaymentRhythmData,
   PaymentsApi,
   PickupLocation,
   PickupLocationsApi,
   Product,
+  PublicProductType,
   Subscription,
   SubscriptionsApi
 } from "../api-client";
 import TapirButton from "../components/TapirButton.tsx";
 import { useApi } from "../hooks/useApi.ts";
 import { ToastData } from "../types/ToastData.ts";
+import { formatDateNumeric } from "../utils/formatDateNumeric.ts";
 import { handleRequestError } from "../utils/handleRequestError.ts";
 
 interface SubscriptionAddContractModalProps {
@@ -38,16 +38,27 @@ const SubscriptionAddButtonModal: React.FC<
   const paymentsApi = useApi(PaymentsApi, csrfToken);
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription>();
-  const [memberData, setMemberData] = useState<Member>();
-  const [paymentsData, setPaymentsData] = useState<MemberPaymentRhythmData>();
-  const [productList, setProductList] = useState<Product[]>();
-  const [periodList, setPeriodList] = useState<GrowingPeriod[]>();
-  const [pickupLocationsList, setPickupLocationsList] =
-    useState<PickupLocation[]>();
+  const [memberName, setMemberName] = useState<string>();
+  const [currentPaymentRhythm, setCurrentPaymentRhythm] = useState<string>("");
+  const [allowedPaymentRhythms, setAllowedPaymentRhythms] = useState<{
+    [key: string]: string;
+  }>({ "": "" });
+  const [productTypesList, setProductTypesList] = useState<PublicProductType[]>(
+    [],
+  );
+  const [productList, setProductList] = useState<Product[]>([]);
+  const [growingPeriodList, setGrowingPeriodList] = useState<GrowingPeriod[]>(
+    [],
+  );
+  const [pickupLocationsList, setPickupLocationsList] = useState<
+    PickupLocation[]
+  >([]);
   const [period, setPeriod] = useState<GrowingPeriod>();
+  const [productType, setProductType] = useState<PublicProductType>();
   const [product, setProduct] = useState<Product>();
-  const [startDate, setStartDate] = useState<Date>();
-  const [endDate, setEndDate] = useState<Date | null | undefined>();
+  const [startDate, setStartDate] = useState<Date>(new Date());
+  const [endDate, setEndDate] = useState<Date>(new Date());
+  const [pickupLocation, setPickupLocation] = useState<PickupLocation>();
   const [paymentRhythm, setPaymentRhythm] = useState<string>();
   const [error, setError] = useState<string>();
 
@@ -56,117 +67,36 @@ const SubscriptionAddButtonModal: React.FC<
 
     setLoading(true);
 
-    coopApi
-      .coopMembersRetrieve({ id: memberId })
-      .then((response) => {
-        setMemberData(response);
-      })
-      .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der persönliche Daten",
-          setToastDatas,
-        ),
+    Promise.all([
+      coopApi.coopMembersRetrieve({ id: memberId }),
+      subscriptionsApi.subscriptionsProductsList(),
+      subscriptionsApi.subscriptionsPublicProductTypesList(),
+      deliveriesApi.deliveriesGrowingPeriodsList(),
+      pickupApi.pickupLocationsPickupLocationsList(),
+      paymentsApi.paymentsApiMemberPaymentRhythmDataRetrieve({
+        memberId: memberId,
+      }),
+    ])
+      .then(
+        ([
+          Member,
+          ProductsList,
+          ProductTypesList,
+          GrowingPeriodList,
+          PickupLocationsList,
+          PaymentRhythmData,
+        ]) => {
+          setMemberName(`${Member.firstName} ${Member.lastName}`);
+          setProductList(ProductsList);
+          setProductTypesList(ProductTypesList);
+          setGrowingPeriodList(GrowingPeriodList);
+          setPickupLocationsList(PickupLocationsList);
+          setCurrentPaymentRhythm(PaymentRhythmData.currentRhythm);
+          setAllowedPaymentRhythms(PaymentRhythmData.allowedRhythms);
+        },
       )
-      .finally(() => setLoading(false));
-  }, [show]);
-
-  useEffect(() => {
-    if (!show) return;
-
-    setLoading(true);
-
-    subscriptionsApi
-      .subscriptionsProductsList()
-      .then((response) => {
-        setProductList(response);
-      })
       .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der Produktliste",
-          setToastDatas,
-        ),
-      )
-      .finally(() => setLoading(false));
-  }, [show]);
-
-  useEffect(() => {
-    if (!show) return;
-
-    setLoading(true);
-
-    deliveriesApi
-      .deliveriesGrowingPeriodsList()
-      .then((response) => {
-        setPeriodList(response);
-      })
-      .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der Produktliste",
-          setToastDatas,
-        ),
-      )
-      .finally(() => setLoading(false));
-  }, [show]);
-
-  useEffect(() => {
-    if (!show) return;
-
-    setLoading(true);
-
-    pickupApi
-      .pickupLocationsPickupLocationsList()
-      .then((response) => {
-        setPickupLocationsList(response);
-      })
-      .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der Produktliste",
-          setToastDatas,
-        ),
-      )
-      .finally(() => setLoading(false));
-  }, [show]);
-
-  useEffect(() => {
-    if (!show) return;
-
-    setLoading(true);
-
-    pickupApi
-      .pickupLocationsPickupLocationsList()
-      .then((response) => {
-        setPickupLocationsList(response);
-      })
-      .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der Produktliste",
-          setToastDatas,
-        ),
-      )
-      .finally(() => setLoading(false));
-  }, [show]);
-
-  useEffect(() => {
-    if (!show) return;
-
-    setLoading(true);
-
-    paymentsApi
-      .paymentsApiMemberPaymentRhythmDataRetrieve({ memberId: memberId })
-      .then((response) => {
-        setPaymentsData(response);
-      })
-      .catch((error) =>
-        handleRequestError(
-          error,
-          "Fehler beim Laden der persönliche Daten",
-          setToastDatas,
-        ),
+        handleRequestError(error, "Fehler beim Laden der Daten", setToastDatas),
       )
       .finally(() => setLoading(false));
   }, [show]);
@@ -175,30 +105,27 @@ const SubscriptionAddButtonModal: React.FC<
     if (loading) {
       return <Spinner />;
     }
-    if (memberData === undefined) {
+    if (memberName === undefined) {
       return <p>Fehler beim Laden der Mitgliedsdaten</p>;
     }
     return (
       <>
         <Row>
-          {periodList && (
-            <Form.Group>
-              <Form.Label>Vertragsperiode</Form.Label>
-              <Form.Select
-                onChange={(event) => {
-                  // @ts-ignore
-                  setPeriod(periodList[event.target.value]);
-                }}
-              >
-                // TODO: When selecting for the first time opt.id is undefined
-                {periodList.map((opt, index) => (
-                  <option key={opt.id} value={index}>
-                    {dayjs(opt.startDate).format("YYYY")}
-                  </option>
-                ))}
-              </Form.Select>
-            </Form.Group>
-          )}
+          <Form.Group>
+            <Form.Label>Vertragsperiode</Form.Label>
+            <Form.Select
+              onChange={(event) => {
+                setPeriod(growingPeriodList[parseInt(event.target.value)]);
+              }}
+            >
+              {growingPeriodList.map((growingPeriod, index) => (
+                <option key={growingPeriod.id} value={index}>
+                  {`${formatDateNumeric(growingPeriod.startDate)} -
+                    ${formatDateNumeric(growingPeriod.endDate)}`}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
         </Row>
         <Row>
           <Col>
@@ -206,7 +133,6 @@ const SubscriptionAddButtonModal: React.FC<
               <Form.Label>Start-Datum</Form.Label>
               <Form.Control
                 type={"date"}
-                value={dayjs(period?.startDate).format("YYYY-MM-DD")}
                 onChange={(event) => {
                   setStartDate(new Date(event.target.value));
                 }}
@@ -218,9 +144,17 @@ const SubscriptionAddButtonModal: React.FC<
               <Form.Label>End-Datum</Form.Label>
               <Form.Control
                 type={"date"}
-                value={dayjs(period?.endDate).format("YYYY-MM-DD")}
                 onChange={(event) => {
-                  setEndDate(new Date(event.target.value));
+                  const selectedDate = new Date(event.target.value);
+                  if (dayjs(selectedDate).format("d") == "0") {
+                    setEndDate(selectedDate);
+                  } else if (new Date(selectedDate) === period?.endDate) {
+                    setEndDate(new Date(selectedDate));
+                  } else {
+                    alert(
+                      "Das End-Datum darf nur an einem Sonntag oder am letzten Tag der Periode sein.",
+                    );
+                  }
                 }}
               />
             </Form.Group>
@@ -236,84 +170,90 @@ const SubscriptionAddButtonModal: React.FC<
         <Row className={"mt-2"}>
           <Col>
             <p>
-              Das End-Datum darf nur am Tag der Kommissioniervariable gesetzt
-              werden (sehe Konfig-Seite).
+              Das End-Datum darf nur an einem Sonntag oder am letzten Tag der
+              Periode sein.
             </p>
           </Col>
         </Row>
         <Row>
-          {periodList && (
+          <Col>
             <Form.Group>
               <Form.Label>Produkttyp</Form.Label>
               <Form.Select
-                onChange={(event) => {
-                  // @ts-ignore
-                  setProduct(productList[event.target.value]);
-                }}
+                onChange={(event) =>
+                  setProductType(productTypesList[parseInt(event.target.value)])
+                }
               >
-                // TODO: When selecting for the first time opt.id is undefined
-                {productList?.map((opt, index) => (
-                  <option key={opt.id} value={index}>
-                    {opt.name}
+                {productTypesList.map((Product, index) => (
+                  <option key={Product.id} value={index}>
+                    {Product.name}
                   </option>
                 ))}
               </Form.Select>
             </Form.Group>
-          )}
-        </Row>
-        <Row>
-          {pickupLocationsList && (
+          </Col>
+          <Col>
             <Form.Group>
-              <Form.Label>Abholort</Form.Label>
+              <Form.Label>Produkt</Form.Label>
               <Form.Select
                 onChange={(event) => {
-                  // @ts-ignore
-                  setProduct(pickupLocationsList[event.target.value]);
+                  setProduct(
+                    productList.find((product) => {
+                      return product.id === event.target.value;
+                    }),
+                  );
                 }}
               >
-                // TODO: When selecting for the first time opt.id is undefined
-                {pickupLocationsList?.map((opt, index) => (
-                  <option key={opt.id} value={index}>
-                    {opt.name}
-                  </option>
-                ))}
+                {productList
+                  .filter((Product) => {
+                    if (productType) {
+                      return Product.type.id === productType.id;
+                    } else {
+                      return Product.type.id === productTypesList[0].id;
+                    }
+                  })
+                  .map((Product) => (
+                    <option key={Product.name} value={Product.id}>
+                      {Product.name}
+                    </option>
+                  ))}
               </Form.Select>
             </Form.Group>
-          )}
+          </Col>
         </Row>
         <Row>
-          {paymentsData && (
-            <Form.Group>
-              <Form.Label>Zahlungsintervall </Form.Label>
-              {paymentsData.currentRhythm && (
-                // TODO: get German name from paymentsData.allowedRythms
-                <Form.Label>: {paymentsData.currentRhythm}</Form.Label>
-              )}
-              {!paymentsData.currentRhythm && (
-                <Form.Select
-                  onChange={(event) => {
-                    setPaymentRhythm(
-                      Object.keys(paymentsData.allowedRhythms)[
-                        // @ts-ignore
-                        event.target.value
-                      ],
-                    );
-                    console.log(paymentsData.currentRhythm);
-                  }}
-                >
-                  // TODO: When selecting for the first time opt.id is undefined
-                  and the indexes dont seem to match
-                  {Object.values(paymentsData?.allowedRhythms).map(
-                    (opt, index) => (
-                      <option key={opt} value={index}>
-                        {opt}
-                      </option>
-                    ),
-                  )}
-                </Form.Select>
-              )}
-            </Form.Group>
-          )}
+          <Form.Group>
+            <Form.Label>Abholort</Form.Label>
+            <Form.Select
+              onChange={(event) => {
+                setPickupLocation(
+                  pickupLocationsList[parseInt(event.target.value)],
+                );
+              }}
+            >
+              {pickupLocationsList?.map((pickupLocation, index) => (
+                <option key={pickupLocation.id} value={index}>
+                  {pickupLocation.name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Row>
+        <Row>
+          <Form.Group>
+            <Form.Label>Zahlungsintervall </Form.Label>
+            <Form.Select
+              onChange={(event) => {
+                setPaymentRhythm(event.target.value);
+              }}
+            >
+              {Object.entries(allowedPaymentRhythms).map(([rhythm, name]) => (
+                <option key={rhythm} value={rhythm}>
+                  {name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
         </Row>
       </>
     );
@@ -324,12 +264,7 @@ const SubscriptionAddButtonModal: React.FC<
       <Modal onHide={onHide} show={show} centered={true} size={"lg"}>
         <Modal.Header closeButton>
           <Modal.Title>
-            {memberData && (
-              <h4>
-                Neuer Vertrag für {memberData.firstName} {memberData.lastName}
-                {", "} {memberData.city}
-              </h4>
-            )}
+            {memberName && <h4>Neuer Vertrag für {memberName}</h4>}
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>{getBodyContent()}</Modal.Body>

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -1,7 +1,6 @@
+import dayjs from "dayjs";
 import React, { useEffect, useState } from "react";
 import { Alert, Col, Form, Modal, Row, Spinner } from "react-bootstrap";
-import { ToastData } from "../types/ToastData.ts";
-import { useApi } from "../hooks/useApi.ts";
 import {
   CoopApi,
   DeliveriesApi,
@@ -15,9 +14,10 @@ import {
   Subscription,
   SubscriptionsApi
 } from "../api-client";
-import { handleRequestError } from "../utils/handleRequestError.ts";
-import dayjs from "dayjs";
 import TapirButton from "../components/TapirButton.tsx";
+import { useApi } from "../hooks/useApi.ts";
+import { ToastData } from "../types/ToastData.ts";
+import { handleRequestError } from "../utils/handleRequestError.ts";
 
 interface SubscriptionAddContractModalProps {
   onHide: () => void;
@@ -34,15 +34,16 @@ const SubscriptionAddButtonModal: React.FC<
   const subscriptionsApi = useApi(SubscriptionsApi, csrfToken);
   const coopApi = useApi(CoopApi, csrfToken);
   const deliveriesApi = useApi(DeliveriesApi, csrfToken);
-  const pickupApi = useApi(PickupLocationsApi, csrfToken)
-  const paymentsApi = useApi(PaymentsApi, csrfToken)
+  const pickupApi = useApi(PickupLocationsApi, csrfToken);
+  const paymentsApi = useApi(PaymentsApi, csrfToken);
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription>();
   const [memberData, setMemberData] = useState<Member>();
   const [paymentsData, setPaymentsData] = useState<MemberPaymentRhythmData>();
   const [productList, setProductList] = useState<Product[]>();
   const [periodList, setPeriodList] = useState<GrowingPeriod[]>();
-  const [pickupLocationsList, setPickupLocationsList] = useState<PickupLocation[]>();
+  const [pickupLocationsList, setPickupLocationsList] =
+    useState<PickupLocation[]>();
   const [period, setPeriod] = useState<GrowingPeriod>();
   const [product, setProduct] = useState<Product>();
   const [startDate, setStartDate] = useState<Date>();
@@ -51,115 +52,14 @@ const SubscriptionAddButtonModal: React.FC<
   const [error, setError] = useState<string>();
 
   useEffect(() => {
-      if (!show) return;
-
-      setLoading(true);
-
-      coopApi
-        .coopMembersRetrieve({ id: memberId })
-        .then((response) => {
-          setMemberData(response)
-        })
-        .catch((error) =>
-          handleRequestError(
-            error,
-            "Fehler beim Laden der persönliche Daten",
-            setToastDatas,
-          ),
-        )
-        .finally(() => setLoading(false));
-    }, [show]);
-
-  useEffect(() => {
-      if (!show) return;
-
-      setLoading(true);
-
-      subscriptionsApi
-        .subscriptionsProductsList()
-        .then((response) => {
-          setProductList(response)
-        })
-        .catch((error) =>
-          handleRequestError(
-            error,
-            "Fehler beim Laden der Produktliste",
-            setToastDatas,
-          ),
-        )
-        .finally(() => setLoading(false));
-    }, [show]);
-
-  useEffect(() => {
-      if (!show) return;
-
-      setLoading(true);
-
-      deliveriesApi
-        .deliveriesGrowingPeriodsList()
-        .then((response) => {
-          setPeriodList(response)
-        })
-        .catch((error) =>
-          handleRequestError(
-            error,
-            "Fehler beim Laden der Produktliste",
-            setToastDatas,
-          ),
-        )
-        .finally(() => setLoading(false));
-    }, [show]);
-
-  useEffect(() => {
-      if (!show) return;
-
-      setLoading(true);
-
-      pickupApi
-        .pickupLocationsPickupLocationsList()
-        .then((response) => {
-          setPickupLocationsList(response)
-        })
-        .catch((error) =>
-          handleRequestError(
-            error,
-            "Fehler beim Laden der Produktliste",
-            setToastDatas,
-          ),
-        )
-        .finally(() => setLoading(false));
-    }, [show]);
-
-
-  useEffect(() => {
-      if (!show) return;
-
-      setLoading(true);
-
-      pickupApi
-        .pickupLocationsPickupLocationsList()
-        .then((response) => {
-          setPickupLocationsList(response)
-        })
-        .catch((error) =>
-          handleRequestError(
-            error,
-            "Fehler beim Laden der Produktliste",
-            setToastDatas,
-          ),
-        )
-        .finally(() => setLoading(false));
-    }, [show]);
-
-  useEffect(() => {
     if (!show) return;
 
     setLoading(true);
 
-    paymentsApi
-      .paymentsApiMemberPaymentRhythmDataRetrieve({ memberId: memberId })
+    coopApi
+      .coopMembersRetrieve({ id: memberId })
       .then((response) => {
-        setPaymentsData(response)
+        setMemberData(response);
       })
       .catch((error) =>
         handleRequestError(
@@ -171,6 +71,105 @@ const SubscriptionAddButtonModal: React.FC<
       .finally(() => setLoading(false));
   }, [show]);
 
+  useEffect(() => {
+    if (!show) return;
+
+    setLoading(true);
+
+    subscriptionsApi
+      .subscriptionsProductsList()
+      .then((response) => {
+        setProductList(response);
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der Produktliste",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  useEffect(() => {
+    if (!show) return;
+
+    setLoading(true);
+
+    deliveriesApi
+      .deliveriesGrowingPeriodsList()
+      .then((response) => {
+        setPeriodList(response);
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der Produktliste",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  useEffect(() => {
+    if (!show) return;
+
+    setLoading(true);
+
+    pickupApi
+      .pickupLocationsPickupLocationsList()
+      .then((response) => {
+        setPickupLocationsList(response);
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der Produktliste",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  useEffect(() => {
+    if (!show) return;
+
+    setLoading(true);
+
+    pickupApi
+      .pickupLocationsPickupLocationsList()
+      .then((response) => {
+        setPickupLocationsList(response);
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der Produktliste",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [show]);
+
+  useEffect(() => {
+    if (!show) return;
+
+    setLoading(true);
+
+    paymentsApi
+      .paymentsApiMemberPaymentRhythmDataRetrieve({ memberId: memberId })
+      .then((response) => {
+        setPaymentsData(response);
+      })
+      .catch((error) =>
+        handleRequestError(
+          error,
+          "Fehler beim Laden der persönliche Daten",
+          setToastDatas,
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [show]);
 
   function getBodyContent() {
     if (loading) {
@@ -189,11 +188,13 @@ const SubscriptionAddButtonModal: React.FC<
                 onChange={(event) => {
                   // @ts-ignore
                   setPeriod(periodList[event.target.value]);
-
-                }}>
+                }}
+              >
                 // TODO: When selecting for the first time opt.id is undefined
                 {periodList.map((opt, index) => (
-                  <option key={opt.id} value={index}>{dayjs(opt.startDate).format("YYYY")}</option>
+                  <option key={opt.id} value={index}>
+                    {dayjs(opt.startDate).format("YYYY")}
+                  </option>
                 ))}
               </Form.Select>
             </Form.Group>
@@ -248,10 +249,13 @@ const SubscriptionAddButtonModal: React.FC<
                 onChange={(event) => {
                   // @ts-ignore
                   setProduct(productList[event.target.value]);
-                }}>
+                }}
+              >
                 // TODO: When selecting for the first time opt.id is undefined
                 {productList?.map((opt, index) => (
-                  <option key={opt.id} value={index}>{opt.name}</option>
+                  <option key={opt.id} value={index}>
+                    {opt.name}
+                  </option>
                 ))}
               </Form.Select>
             </Form.Group>
@@ -265,10 +269,13 @@ const SubscriptionAddButtonModal: React.FC<
                 onChange={(event) => {
                   // @ts-ignore
                   setProduct(pickupLocationsList[event.target.value]);
-                }}>
+                }}
+              >
                 // TODO: When selecting for the first time opt.id is undefined
                 {pickupLocationsList?.map((opt, index) => (
-                  <option key={opt.id} value={index}>{opt.name}</option>
+                  <option key={opt.id} value={index}>
+                    {opt.name}
+                  </option>
                 ))}
               </Form.Select>
             </Form.Group>
@@ -280,22 +287,32 @@ const SubscriptionAddButtonModal: React.FC<
               <Form.Label>Zahlungsintervall </Form.Label>
               {paymentsData.currentRhythm && (
                 // TODO: get German name from paymentsData.allowedRythms
-                  <Form.Label>: {paymentsData.currentRhythm}</Form.Label>
+                <Form.Label>: {paymentsData.currentRhythm}</Form.Label>
               )}
               {!paymentsData.currentRhythm && (
                 <Form.Select
                   onChange={(event) => {
-                    // @ts-ignore
-                    setPaymentRhythm(Object.keys(paymentsData.allowedRhythms)[event.target.value]);
-                    console.log(paymentsData.currentRhythm)
-                  }}>
-                  // TODO: When selecting for the first time opt.id is undefined and the indexes dont seem to match
-                  {Object.values(paymentsData?.allowedRhythms).map((opt, index) => (
-                    <option key={opt} value={index}>{opt}</option>
-                  ))}
+                    setPaymentRhythm(
+                      Object.keys(paymentsData.allowedRhythms)[
+                        // @ts-ignore
+                        event.target.value
+                      ],
+                    );
+                    console.log(paymentsData.currentRhythm);
+                  }}
+                >
+                  // TODO: When selecting for the first time opt.id is undefined
+                  and the indexes dont seem to match
+                  {Object.values(paymentsData?.allowedRhythms).map(
+                    (opt, index) => (
+                      <option key={opt} value={index}>
+                        {opt}
+                      </option>
+                    ),
+                  )}
                 </Form.Select>
               )}
-              </Form.Group>
+            </Form.Group>
           )}
         </Row>
       </>
@@ -309,14 +326,13 @@ const SubscriptionAddButtonModal: React.FC<
           <Modal.Title>
             {memberData && (
               <h4>
-                Neuer Vertrag für {memberData.firstName} {memberData.lastName}{", "} {memberData.city}
+                Neuer Vertrag für {memberData.firstName} {memberData.lastName}
+                {", "} {memberData.city}
               </h4>
             )}
           </Modal.Title>
         </Modal.Header>
-        <Modal.Body>
-          {getBodyContent()}
-        </Modal.Body>
+        <Modal.Body>{getBodyContent()}</Modal.Body>
         <Modal.Footer>
           <TapirButton
             variant={"primary"}

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -64,7 +64,7 @@ const SubscriptionAddButtonModal: React.FC<
   const [endDate, setEndDate] = useState<Date>(new Date());
   const [pickupLocation, setPickupLocation] = useState<PickupLocation>();
   const [paymentRhythm, setPaymentRhythm] = useState<string>();
-  const [error, setError] = useState<string>();
+  const [error] = useState<string>();
 
   // TODO add Create Contract API Call
 

--- a/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
+++ b/src_frontend/subscription_list/SubscriptionAddContractModal.tsx
@@ -5,6 +5,7 @@ import {
   CoopApi,
   DeliveriesApi,
   GrowingPeriod,
+  Mpl,
   PaymentsApi,
   PickupLocation,
   PickupLocationsApi,
@@ -39,7 +40,9 @@ const SubscriptionAddButtonModal: React.FC<
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription>();
   const [memberName, setMemberName] = useState<string>();
-  const [currentPaymentRhythm, setCurrentPaymentRhythm] = useState<string>("");
+  const [currentPaymentRhythm, setCurrentPaymentRhythm] = useState<
+    string | undefined
+  >();
   const [allowedPaymentRhythms, setAllowedPaymentRhythms] = useState<{
     [key: string]: string;
   }>({ "": "" });
@@ -53,6 +56,7 @@ const SubscriptionAddButtonModal: React.FC<
   const [pickupLocationsList, setPickupLocationsList] = useState<
     PickupLocation[]
   >([]);
+  const [memberPickupLocation, setMemberPickupLocation] = useState<Mpl>();
   const [period, setPeriod] = useState<GrowingPeriod>();
   const [productType, setProductType] = useState<PublicProductType>();
   const [product, setProduct] = useState<Product>();
@@ -61,6 +65,8 @@ const SubscriptionAddButtonModal: React.FC<
   const [pickupLocation, setPickupLocation] = useState<PickupLocation>();
   const [paymentRhythm, setPaymentRhythm] = useState<string>();
   const [error, setError] = useState<string>();
+
+  // TODO add Create Contract API Call
 
   useEffect(() => {
     if (!show) return;
@@ -73,9 +79,8 @@ const SubscriptionAddButtonModal: React.FC<
       subscriptionsApi.subscriptionsPublicProductTypesList(),
       deliveriesApi.deliveriesGrowingPeriodsList(),
       pickupApi.pickupLocationsPickupLocationsList(),
-      paymentsApi.paymentsApiMemberPaymentRhythmDataRetrieve({
-        memberId: memberId,
-      }),
+      pickupApi.pickupLocationsApiGetMemberPickupLocationRetrieve({ memberId }),
+      paymentsApi.paymentsApiMemberPaymentRhythmDataRetrieve({ memberId }),
     ])
       .then(
         ([
@@ -84,6 +89,7 @@ const SubscriptionAddButtonModal: React.FC<
           ProductTypesList,
           GrowingPeriodList,
           PickupLocationsList,
+          MemberPickupLocation,
           PaymentRhythmData,
         ]) => {
           setMemberName(`${Member.firstName} ${Member.lastName}`);
@@ -91,6 +97,7 @@ const SubscriptionAddButtonModal: React.FC<
           setProductTypesList(ProductTypesList);
           setGrowingPeriodList(GrowingPeriodList);
           setPickupLocationsList(PickupLocationsList);
+          setMemberPickupLocation(MemberPickupLocation);
           setCurrentPaymentRhythm(PaymentRhythmData.currentRhythm);
           setAllowedPaymentRhythms(PaymentRhythmData.allowedRhythms);
         },
@@ -149,7 +156,7 @@ const SubscriptionAddButtonModal: React.FC<
                   if (dayjs(selectedDate).format("d") == "0") {
                     setEndDate(selectedDate);
                   } else if (new Date(selectedDate) === period?.endDate) {
-                    setEndDate(new Date(selectedDate));
+                    setEndDate(selectedDate);
                   } else {
                     alert(
                       "Das End-Datum darf nur an einem Sonntag oder am letzten Tag der Periode sein.",
@@ -206,11 +213,9 @@ const SubscriptionAddButtonModal: React.FC<
               >
                 {productList
                   .filter((Product) => {
-                    if (productType) {
-                      return Product.type.id === productType.id;
-                    } else {
-                      return Product.type.id === productTypesList[0].id;
-                    }
+                    return productType
+                      ? Product.type.id === productType.id
+                      : Product.type.id === productTypesList[0].id;
                   })
                   .map((Product) => (
                     <option key={Product.name} value={Product.id}>
@@ -231,29 +236,43 @@ const SubscriptionAddButtonModal: React.FC<
                 );
               }}
             >
-              {pickupLocationsList?.map((pickupLocation, index) => (
-                <option key={pickupLocation.id} value={index}>
-                  {pickupLocation.name}
-                </option>
-              ))}
+              {pickupLocationsList
+                .filter((pickupLocation) => {
+                  return memberPickupLocation?.hasLocation
+                    ? pickupLocation.id === memberPickupLocation.location?.id
+                    : [];
+                })
+                .map((pickupLocation, index) => (
+                  <option key={pickupLocation.id} value={index}>
+                    {pickupLocation.name}
+                  </option>
+                ))}
             </Form.Select>
           </Form.Group>
         </Row>
         <Row>
-          <Form.Group>
-            <Form.Label>Zahlungsintervall </Form.Label>
-            <Form.Select
-              onChange={(event) => {
-                setPaymentRhythm(event.target.value);
-              }}
-            >
-              {Object.entries(allowedPaymentRhythms).map(([rhythm, name]) => (
-                <option key={rhythm} value={rhythm}>
-                  {name}
-                </option>
-              ))}
-            </Form.Select>
-          </Form.Group>
+          {Object.entries(allowedPaymentRhythms).length > 1 && (
+            <Form.Group>
+              <Form.Label>Zahlungsintervall </Form.Label>
+              <Form.Select
+                onChange={(event) => {
+                  setPaymentRhythm(event.target.value);
+                }}
+              >
+                {Object.entries(allowedPaymentRhythms)
+                  .filter(([rhythm, name]) => {
+                    return currentPaymentRhythm
+                      ? currentPaymentRhythm === rhythm
+                      : [];
+                  })
+                  .map(([rhythm, name]) => (
+                    <option key={rhythm} value={rhythm}>
+                      {name}
+                    </option>
+                  ))}
+              </Form.Select>
+            </Form.Group>
+          )}
         </Row>
       </>
     );

--- a/src_frontend/subscription_list/SubscriptionChangeDatesButton.tsx
+++ b/src_frontend/subscription_list/SubscriptionChangeDatesButton.tsx
@@ -25,7 +25,7 @@ const SubscriptionChangeDatesButton: React.FC<
         onClick={() => {
           const subscriptionId = getParameterFromUrl("contract");
           if (!subscriptionId) {
-            alert("Du musst erst das Vertrag auswählen.");
+            alert("Du musst erst den Vertrag auswählen.");
             return;
           }
           setSubscriptionId(subscriptionId);

--- a/src_frontend/subscription_list/subscription_list_entry.tsx
+++ b/src_frontend/subscription_list/subscription_list_entry.tsx
@@ -1,9 +1,13 @@
 import { createRoot } from "react-dom/client";
 import SubscriptionChangeDatesButton from "./SubscriptionChangeDatesButton.tsx";
+import SubscriptionAddContractButton from "./SubscriptionAddContractButton.tsx";
 import { getCsrfToken } from "../utils/getCsrfToken.ts";
 
 const domNodeSubscriptionChangeDatesButton = document.getElementById(
   "subscription_change_dates_button",
+);
+const domNodeSubscriptionAddContractButton = document.getElementById(
+    "subscription_add_contract_button",
 );
 
 if (!domNodeSubscriptionChangeDatesButton) {
@@ -11,4 +15,11 @@ if (!domNodeSubscriptionChangeDatesButton) {
 } else {
   const root = createRoot(domNodeSubscriptionChangeDatesButton);
   root.render(<SubscriptionChangeDatesButton csrfToken={getCsrfToken()} />);
+}
+
+if (!domNodeSubscriptionAddContractButton) {
+  console.error("Subscription add contract button not found");
+} else {
+  const root = createRoot(domNodeSubscriptionAddContractButton);
+  root.render(<SubscriptionAddContractButton csrfToken={getCsrfToken()} />);
 }

--- a/tapir/wirgarten/templates/wirgarten/subscription/subscription_filter.html
+++ b/tapir/wirgarten/templates/wirgarten/subscription/subscription_filter.html
@@ -16,6 +16,7 @@
 {% block card_header %}
     <h4 class="mb-0">{{ number_of_contracts }} {% translate 'Verträge' %}, {{ quantity_sum }} Anteile</h4>
     <span style="display: flex; flex-direction:row;">
+        <span id="subscription_add_contract_button" class="mx-1 p-0"></span>
         <span id="subscription_change_dates_button" class="mx-1 p-0"></span>
         {% if perms.accounts.manage %}
             {% include 'wirgarten/generic/action-button.html' with onclick='handleEditPrice()' disabled=True title='Betrag ändern' type='primary' icon='edit' class='needs-contract d-flex' %}


### PR DESCRIPTION
Issue #1037 

- [x] unter "Verträge" ein weiteres Icon oben in der Icon-Liste habe (ganz links); 
- [x] "Vertrag hinzufügen" als Hover-Text
- [x] Bei Klick auf das Icon erscheint Popup
- [x] Vertragsperiode
- [x] Vertragsstart (muss Montag sein, idealerweise Angabe der KW-Nr. mit Vorschau, welches Datum der Mo. hat)
- [x] Vertragsende (i. d. R. Vertragsperiodenende, kann auch schon vorgegeben werden, kann aber abänderbar sein; dann immer auf einen Sonntag hin, Anmerkung oben
- [x] Produkttype auswählen
- [x] Produktanteilsgröße auswählen
- [x] Abholort hinzufügen (nur die auswählbar machen, die frei sind und Kapas haben), sofern kein Abholort bereits hinterlegt (falls hinterlegt, dann diesen nehmen)
- [x] sofern noch kein Zahlungsintervall hinterlegt, dann Angabe des Zahlungsintervalls erforderlich (falls hinterlegt, dann dieses nehmen)
- [ ] im Idealfall kann ich mehrere Produktverträge gleichzeitig erstellen


### Ausgeklammert, siehe Diskussion
- [ ]  Suchfeld, wo alle Mitglieder mit Nr, Vorname und Nachname aufgeführt werden und suchbar sind
- [ ] (Kombinationen von Nr, Vorname und Nachname etc.). --> mit Fragezeichen dahinter und Möglichkeit, dass ich Hilfstext hinterlege.
- [ ] Nach Auswahl des Mitgliedes kann ich dann die Vertragsangaben machen
